### PR TITLE
fix: typo in menu bar（Ctrol→Ctrl）

### DIFF
--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -100,7 +100,7 @@ TODO: Split the component into the following units
                   <span class="bg-gray-200 dark:bg-gray-600 dark:text-gray-200 rounded-3px px-5px py-4px inline-block">↓</span>
                   or
                   <span class="bg-gray-200 dark:bg-gray-600 dark:text-gray-200 rounded-3px px-5px py-4px inline-block mr-3px">Ctrl + n</span>
-                  <span class="bg-gray-200 dark:bg-gray-600 dark:text-gray-200 rounded-3px px-5px py-4px inline-block mr-3px">Ctrol + p</span>
+                  <span class="bg-gray-200 dark:bg-gray-600 dark:text-gray-200 rounded-3px px-5px py-4px inline-block mr-3px">Ctrl + p</span>
                   Navigate,
                 </p>
                 <p class="mr-10px">


### PR DESCRIPTION
This PR fixes typo in menu bar(`ctrol + p`→`ctrl + p`).

## UI

Before

![CleanShot 2022-01-12 at 14 53 33](https://user-images.githubusercontent.com/61409641/149071780-4bd5f0cb-356d-4483-9261-96bdeb5db51f.png)

After
![CleanShot 2022-01-12 at 14 47 43](https://user-images.githubusercontent.com/61409641/149071558-5207d911-e9cc-4968-bf62-622677d0a5b8.png)

---

Thank you for developing the best product!😁
I love productivity tools! Chikamichi is exactly what I was looking for!