### PR TITLE
ポップアップの表示コマンドの修正

### DIFF
--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -13,7 +13,7 @@
     <div class="text-center mt-10px">
       <span class="bg-gray-200 dark:bg-gray-600 dark:text-white rounded-3px px-8px py-4px inline-block mr-3px">Alt</span>
       <span class="dark:text-white mr-3px">+</span>
-      <span class="bg-gray-200 dark:bg-gray-600 dark:text-white rounded-3px px-8px py-4px inline-block mr-3px">p</span>
+      <span class="bg-gray-200 dark:bg-gray-600 dark:text-white rounded-3px px-8px py-4px inline-block mr-3px">k</span>
     </div>
     <!-- TODO enable dark mode -->
     <!--    <div class="mt-2">-->


### PR DESCRIPTION
(意図が違ったらすいません)

ポップアップに表示されるショートカットが違いそうなので修正しました。

**修正内容**
`Alt + p` -> `Alt + k`

**修正対象の画面**
![image](https://user-images.githubusercontent.com/33852683/149075518-88f6e9d4-19fc-42e7-ac23-426aae4a7c4b.png)

