### PR TITLE
style: expand url space

### DIFF
--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -47,11 +47,11 @@ TODO: Split the component into the following units
                       @click="onClick(item.url, item.tabId)"
                     >
                       <button class="p-6px block text-13px flex items-center text-black justify-between border-none w-full cursor-pointer bg-white rounded-5px dark:bg-gray-800 dark:text-gray-200" type="button" :class="{ 'bg-blue-200': i === selectedNumber, 'dark:bg-blue-700': i === selectedNumber }">
-                        <span class="flex items-center w-440px">
+                        <span class="flex items-center w-540px">
                           <img :src="item.faviconUrl" alt="" class="w-16px h-16px mr-8px inline-block" />
                           <span class="overflow-hidden block whitespace-nowrap text-over overflow-ellipsis mr-5px">{{ item.title }}</span>
-                          <span class="overflow-hidden text-gray-400 text-11px block whitespace-nowrap text-over overflow-ellipsis max-w-200px">
-                            {{ item.url }}
+                          <span class="overflow-hidden text-gray-400 text-11px block whitespace-nowrap text-over overflow-ellipsis max-w-300px ml-auto mr-5px">
+                            {{ item.url.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '') }}
                           </span>
                         </span>
                         <span class="px-8px py-3px rounded-5px text-gray-400 bg-gray-100 dark:bg-gray-600 dark:text-gray-200">


### PR DESCRIPTION
## Overview
In this PR, I expanded the display area of search results, especially urls.

## Why
- To increase the amount of information visible to the users.

## What
- Change width of flex area including icon, title and url to 540px.
- Change max width of url area to 300px.
- Add left margin to url area.
- Remove `https://www.` from url displayed in the search results.

## Demo
<img width="600" alt="CleanShot 2022-01-14 at 11 38 13@2x" src="https://user-images.githubusercontent.com/10044588/149448107-27d58e7e-bbc5-4cd9-8ecb-ea7cef3110a3.png">