### PR TITLE
Adding submit github action

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -1,0 +1,33 @@
+name: "submit"
+on: 
+  workflow_dispatch:
+    
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache pnpm modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 6.30.1
+          run_install: true
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: "pnpm"
+      - run: |
+          pnpm run build
+          pnpm run pack
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ src/auto-imports.d.ts
 src/components.d.ts
 components.d.ts
 yarn.lock
+keys.json


### PR DESCRIPTION
Hi @kawamataryo,

Thanks for making chikamichi - your extension is awesome! 

I was looking for some way to contribute, and thought that maybe an automated submission pipeline for the zip archive could be helpful. I created a github action called [bpp](https://github.com/marketplace/actions/browser-plugin-publisher) that can submit the zip to the Chrome/Firefox stores automatically for you. It is set to run manually from the github action tab, but we can tweak it to run as frequent as you wish! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "zip": "./extension.crx",
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./extension.xpi",
    "extId": "123",
    "sessionid": "abcd"
  }
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)