### PR TITLE
feat: set url if bookmark title is empty

### DIFF
--- a/src/popup/utils/__tests__/getSearchItems.spec.ts
+++ b/src/popup/utils/__tests__/getSearchItems.spec.ts
@@ -10,7 +10,9 @@ import { SEARCH_ITEM_TYPE } from "~/constants";
 
 vi.mock("webextension-polyfill", () => ({}));
 
-const generateBookmark = (): Bookmarks.BookmarkTreeNode => ({
+const generateBookmark = (overwrites?: {
+  title?: string;
+}): Bookmarks.BookmarkTreeNode => ({
   id: randUuid(),
   parentId: randUuid(),
   index: randNumber(),
@@ -19,6 +21,7 @@ const generateBookmark = (): Bookmarks.BookmarkTreeNode => ({
   dateAdded: randNumber(),
   dateGroupModified: randNumber(),
   type: "bookmark" as const,
+  ...overwrites,
 });
 
 const generateHistory = (
@@ -34,6 +37,7 @@ describe("convertToSearchItemsFromBookmarks", () => {
     const bookmark1 = generateBookmark();
     const bookmark2 = generateBookmark();
     const bookmark3 = generateBookmark();
+    const bookmark4 = generateBookmark({ title: "" });
     const nestedFolder = {
       ...generateBookmark(),
       type: "folder" as const,
@@ -44,11 +48,11 @@ describe("convertToSearchItemsFromBookmarks", () => {
       type: "folder" as const,
       children: [bookmark2, nestedFolder],
     };
-    const bookmarks = [bookmark1, folder];
+    const bookmarks = [bookmark1, folder, bookmark4];
 
     const searchItems = convertToSearchItemsFromBookmarks(bookmarks);
 
-    expect(searchItems.length).toBe(3);
+    expect(searchItems.length).toBe(4);
     expect(searchItems).toEqual([
       {
         url: bookmark1.url,
@@ -73,6 +77,14 @@ describe("convertToSearchItemsFromBookmarks", () => {
         type: SEARCH_ITEM_TYPE.BOOKMARK,
         folderName: `${folder.title}/${nestedFolder.title}`,
         searchTerm: `${bookmark3.title} ${bookmark3.url} ${folder.title}/${nestedFolder.title}`,
+      },
+      {
+        url: bookmark4.url,
+        title: bookmark4.url,
+        faviconUrl: faviconUrl(bookmark4.url!),
+        type: SEARCH_ITEM_TYPE.BOOKMARK,
+        folderName: "",
+        searchTerm: `${bookmark4.url}`,
       },
     ]);
   });

--- a/src/popup/utils/getSearchItems.ts
+++ b/src/popup/utils/getSearchItems.ts
@@ -68,7 +68,7 @@ export const convertToSearchItemsFromBookmarks = (
           : folderNames.filter((name) => name).join("/"); // Exclude top level folder name
       result.push({
         url: node.url,
-        title: node.title,
+        title: node.title || node.url,
         faviconUrl: faviconUrl(node.url),
         type: SEARCH_ITEM_TYPE.BOOKMARK,
         folderName,


### PR DESCRIPTION
I have not set titles for some of my bookmark bars.
In that case, I show the URL as the title of the bookmark type.

![image](https://user-images.githubusercontent.com/20282867/157561504-20ea48a5-fd6f-4262-9b8c-e9e4926bee37.png)

before

![範囲を選択_343](https://user-images.githubusercontent.com/20282867/157561439-0baee393-d6a8-4c74-bf51-58e1bb5c602f.png)

after

![範囲を選択_342](https://user-images.githubusercontent.com/20282867/157561425-d3e8a241-8d62-47b3-a2e2-e74c75429b5d.png)
