### PR TITLE
Upgrade bpp to v2

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -27,6 +27,6 @@ jobs:
           pnpm run build
           pnpm run pack
       - name: Browser Plugin Publish
-        uses: plasmo-corp/bpp@v1
+        uses: PlasmoHQ/bpp@v2
         with:
           keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Upgrades the Browser Plugin Publish Github action to v2. We also renamed our organization which is why that's different now!

The new version adds support for the Edge Web Store Add-Ons API and improved reliability.


⚠️ Heads up the schema's changed a bit ⚠️

Here's an updated representation: https://raw.githubusercontent.com/PlasmoHQ/bpp/v2/keys.schema.json
Here's an example: https://github.com/PlasmoHQ/bpp/blob/main/keys.template.json

