### PR TITLE
[codex] Dedupe similar history search URLs

### DIFF
--- a/src/popup-react/components/result-rows.tsx
+++ b/src/popup-react/components/result-rows.tsx
@@ -1,11 +1,43 @@
-import { memo } from "react";
-import { ArrowUpRight, GripVertical, Pin, PinOff } from "lucide-react";
+import { memo, useEffect, useState } from "react";
+import { ArrowUpRight, Globe2, GripVertical, Pin, PinOff } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
 import { cn } from "~/lib/utils";
 import { t } from "~/i18n";
 import { highlightText } from "~/popup-react/utils";
 import type { ActionItem } from "~/popup-react/types";
 import type { CommandItem } from "~/popup-react/command-items";
+
+function FaviconImage({ src }: { src: string }) {
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
+  if (!src || failed) {
+    return (
+      <span
+        aria-hidden="true"
+        className="flex size-[18px] items-center justify-center rounded-sm border border-border-product bg-control-surface text-foreground/46 dark:bg-control-surface/70 dark:text-muted-foreground"
+      >
+        <Globe2 className="size-3" />
+      </span>
+    );
+  }
+
+  return (
+    <img
+      alt=""
+      className="size-[18px] rounded-sm"
+      height="18"
+      src={src}
+      width="18"
+      onError={() => {
+        setFailed(true);
+      }}
+    />
+  );
+}
 
 // oxlint-disable-next-line prefer-arrow-callback
 const SearchResultRow = memo(function SearchResultRow({
@@ -108,7 +140,7 @@ const SearchResultRow = memo(function SearchResultRow({
           <GripVertical className="size-3.5" />
         </button>
       ) : null}
-      <img alt="" className="size-[18px] rounded-sm" height="18" src={item.faviconUrl} width="18" />
+      <FaviconImage src={item.faviconUrl} />
       <div className="min-w-0">
         <div className="text-body truncate font-medium">
           {highlightText(item.title, item.matchedWord)}
@@ -291,13 +323,7 @@ export const CommandResultRow = memo(function CommandResultRow({
         handlePointerSelection(index, event.clientX, event.clientY);
       }}
     >
-      <img
-        alt=""
-        className="size-[18px] rounded-sm"
-        height="18"
-        src={commandItem.faviconUrl}
-        width="18"
-      />
+      <FaviconImage src={commandItem.faviconUrl} />
       <div className="min-w-0">
         <div className="text-body truncate font-medium text-foreground">{commandItem.title}</div>
         <div className="text-caption truncate text-foreground/[0.56] dark:text-muted-foreground">

--- a/src/popup/utils/__tests__/getSearchItems.spec.ts
+++ b/src/popup/utils/__tests__/getSearchItems.spec.ts
@@ -184,9 +184,9 @@ describe("convertToSearchItemsFromBookmarks", () => {
 
   it("remove same title histories", () => {
     const histories = [
-      generateHistory({ title: "titleA" }),
+      { ...generateHistory({ title: "titleA" }), lastVisitTime: 100 },
       generateHistory({ title: "titleB" }),
-      generateHistory({ title: "titleA" }),
+      { ...generateHistory({ title: "titleA" }), lastVisitTime: 200 },
     ];
 
     const searchItems = convertToSearchItemsFromHistories(histories);
@@ -203,10 +203,75 @@ describe("convertToSearchItemsFromBookmarks", () => {
     expect(searchItems).toContainEqual({
       faviconUrl: faviconUrl(histories[2].url!),
       folderName: "",
+      lastVisitTime: 200,
       searchTerm: `${histories[2].title!} ${histories[2].url}`,
       title: histories[2].title!,
       type: SEARCH_ITEM_TYPE.HISTORY,
       url: histories[2].url,
+    });
+  });
+
+  it("remove histories with the same comparable url", () => {
+    const histories = [
+      {
+        ...generateHistory({
+          title: "older docs",
+          url: "https://docs.example.com/path/?utm_source=newsletter#intro",
+        }),
+        lastVisitTime: 100,
+      },
+      {
+        ...generateHistory({
+          title: "latest docs",
+          url: "https://docs.example.com/path?ref=popup",
+        }),
+        lastVisitTime: 200,
+      },
+      {
+        ...generateHistory({
+          title: "other docs",
+          url: "https://docs.example.com/other",
+        }),
+        lastVisitTime: 150,
+      },
+      {
+        ...generateHistory({
+          title: "search docs",
+          url: "https://docs.example.com/path?q=api",
+        }),
+        lastVisitTime: 50,
+      },
+    ];
+
+    const searchItems = convertToSearchItemsFromHistories(histories);
+
+    expect(searchItems.length).toBe(3);
+    expect(searchItems).toContainEqual({
+      faviconUrl: faviconUrl(histories[1].url!),
+      folderName: "",
+      lastVisitTime: 200,
+      searchTerm: `${histories[1].title!} ${histories[1].url}`,
+      title: histories[1].title!,
+      type: SEARCH_ITEM_TYPE.HISTORY,
+      url: histories[1].url,
+    });
+    expect(searchItems).toContainEqual({
+      faviconUrl: faviconUrl(histories[2].url!),
+      folderName: "",
+      lastVisitTime: 150,
+      searchTerm: `${histories[2].title!} ${histories[2].url}`,
+      title: histories[2].title!,
+      type: SEARCH_ITEM_TYPE.HISTORY,
+      url: histories[2].url,
+    });
+    expect(searchItems).toContainEqual({
+      faviconUrl: faviconUrl(histories[3].url!),
+      folderName: "",
+      lastVisitTime: 50,
+      searchTerm: `${histories[3].title!} ${histories[3].url}`,
+      title: histories[3].title!,
+      type: SEARCH_ITEM_TYPE.HISTORY,
+      url: histories[3].url,
     });
   });
 

--- a/src/popup/utils/getSearchItems.ts
+++ b/src/popup/utils/getSearchItems.ts
@@ -10,15 +10,40 @@ function generateSearchTerm(...args: string[]): string {
   return args.filter((arg) => arg).join(" ");
 }
 
-function removeDeprecatedItem(searchItems: SearchItem[], key: "title" | "url") {
-  return Array.from(
-    searchItems
-      .reduce(
-        (map, currentItem) => map.set(currentItem[key], currentItem),
-        new Map<string, SearchItem>(),
-      )
-      .values(),
-  );
+const TRACKING_SEARCH_PARAMS = new Set(["fbclid", "gclid", "ref"]);
+
+function isTrackingSearchParam(paramName: string) {
+  return paramName.startsWith("utm_") || TRACKING_SEARCH_PARAMS.has(paramName);
+}
+
+function removeDuplicatedItems(
+  searchItems: SearchItem[],
+  getKey: (searchItem: SearchItem) => string,
+) {
+  const seenKeys = new Set<string>();
+  return searchItems.filter((searchItem) => {
+    const key = getKey(searchItem);
+    if (seenKeys.has(key)) {
+      return false;
+    }
+
+    seenKeys.add(key);
+    return true;
+  });
+}
+
+function comparableHistoryUrl(url: string) {
+  try {
+    const parsedUrl = new URL(url);
+    parsedUrl.hash = "";
+    Array.from(parsedUrl.searchParams.keys())
+      .filter(isTrackingSearchParam)
+      .forEach((paramName) => parsedUrl.searchParams.delete(paramName));
+    parsedUrl.pathname = parsedUrl.pathname.replace(/\/+$/u, "") || "/";
+    return parsedUrl.toString();
+  } catch {
+    return url;
+  }
 }
 
 export function convertToSearchItemsFromHistories(histories: History.HistoryItem[]): SearchItem[] {
@@ -41,8 +66,10 @@ export function convertToSearchItemsFromHistories(histories: History.HistoryItem
     }))
     .sort((a, b) => (b.lastVisitTime ?? 0) - (a.lastVisitTime ?? 0));
 
-  // Remove same title items
-  return removeDeprecatedItem(searchItems, "title");
+  return removeDuplicatedItems(
+    removeDuplicatedItems(searchItems, (searchItem) => comparableHistoryUrl(searchItem.url)),
+    (searchItem) => searchItem.title,
+  );
 }
 
 export function convertToSearchItemsFromBookmarks(


### PR DESCRIPTION
## Summary
- Deduplicate history search items by comparable URL before title dedupe
- Normalize history URLs by ignoring hashes, trailing slashes, and common tracking query parameters
- Keep meaningful query parameters such as search terms so distinct pages remain searchable
- Show a compact globe fallback icon when a favicon URL is empty or fails to load
- Keep the most recently visited matching history item

## Why
Repeated history entries for the same page with tracking/hash variants made the popup search results harder to scan. Missing favicons also left result rows visually inconsistent.

## Validation
- pnpm check