### PR TITLE
docs: document reorder favorites feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Please install from:
 | `Ctrl + f`                            | Pin or unpin the selected item in Chikamichi                            |
 | `Ctrl + c`                            | Copy the selected URL to the clipboard                                  |
 | `Ctrl + d`                            | Delete the selected history, remove bookmark, or close tab by item type |
+| `Ctrl + Shift + N`                    | Move the selected pinned item down (when search input is empty)         |
+| `Ctrl + Shift + P`                    | Move the selected pinned item up (when search input is empty)           |
 
 ### Search commands
 
@@ -77,6 +79,15 @@ Open Help from the sidebar to see a command-style reference for search, navigati
 ### Favorite
 
 Items with a star to the right of the search item are registered as favorites. Items registered as favorites will be displayed in the initial view. However, if a search prefix has been set, the search prefix will take precedence.
+
+### Reordering Favorites
+
+When the search input is empty and you have two or more pinned items, a drag handle (⠿) appears to the left of each favorite. You can change the display order in two ways:
+
+- **Drag and drop** — grab the handle on the left side of any pinned item and drop it onto another item to swap positions.
+- **Keyboard** — select a pinned item with `↑` / `↓`, then press `Ctrl + Shift + N` to move it down or `Ctrl + Shift + P` to move it up.
+
+The new order is saved automatically and persists across sessions.
 
 ## 👨‍💻 Contributing
 


### PR DESCRIPTION
Closes #685

Adds documentation for the reorder favorites feature to the README, explaining how users can change the display order of their saved items.

**What changed:**
- Added two new keyboard shortcut rows to the Shortcuts table (`Ctrl+Shift+N` / `Ctrl+Shift+P` for moving pinned items up/down)
- Added a new **Reordering Favorites** subsection under the Favorite section describing both the drag-and-drop handle and the keyboard method, plus noting that the order persists automatically

**How I verified the docs are accurate:**
I traced the implementation in `src/popup-react/favorites.ts` (`moveFavoriteItem`, `moveFavoriteItemToIndex`), `src/popup-react/pages/SearchPage.tsx` (`moveFavorite`, `reorderFavorite`, `favoriteReorderEnabled`), and `src/popup-react/components/result-rows.tsx` (drag handle rendering, `onDragStart`/`onDrop` handlers). The shortcuts are handled in `handleShortcutKey` (`Ctrl+Shift+N` → `moveFavorite("down")`, `Ctrl+Shift+P` → `moveFavorite("up")`). Drag-and-drop is only active when the search input is empty and there are 2+ pinned items, which matches what the docs say.